### PR TITLE
Update website content: 2023–2025 publications, current students, 2025 awards, SE4AI research topic

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,17 +45,22 @@
                         <span class="text-primary">, PhD</span>
                     </h1>
                     <div class="subheading mb-5">
-                        Assistant Professor, Federal University of Mato Grosso do Sul (UFMS), Faculty of Computing (FACOM)
+                        Professor Adjunto e Coordenador do PPGCC &middot; FACOM/UFMS &middot;
                         <a href="mailto:awdren.fontao@ufms.br">awdren.fontao@ufms.br</a>
                     </div>
-                    <p class="lead mb-5">PhD and Master by the Graduate Program in Informatics at the Institute of Computing (ICOMP) at the Federal University of Amazonas (UFAM). Bachelor of Computer Science from UFAM. He worked as a Technical Specialist (PhD) at SIDIA Institute of Science and Technology in Deep Learning and Emotional Text-To-Speech projects, as well as collaboration in the area of ​​Verification, Validation and Software Testing. He has experience with developer communities, where he worked for six years in the DevRel area as a developer evangelist for Nokia and Microsoft, in Brazil and Latin America. In this field, he participated in the organization of hackathons, developer conferences and training, in addition to technical team leadership. He serves as reviewer of journals and technical committees of conference and workshop programs. It has already been awarded as one of the best master's theses in computing in Brazil by SBC, as well as in the area of ​​software quality by SBQS. He is interested, within the Software Engineering area, in research on Developer Relations (DevRel), Software Ecosystems, Mining Software Repositories, Software Engineering applied to Machine Learning and Experimental Software Engineering. Member of the UFMS Software and Database Engineering Group, the UFAM Software Experimentation and Testing Group (ExperTS) and the UNIRIO Complex Systems Engineering Laboratory (Lab Esc).</p>
-                    <a href="https://dblp.org/pers/f/Font=atilde=o:Awdren_de_Lima.html">DBLP | </a>
-                    <a href="https://scholar.google.com.br/citations?user=BfesYF0AAAAJ&hl=en">Google Scholar | </a>
-                    <a href="https://www.researchgate.net/profile/Awdren_Fontao">Research Gate | </a>
-                    <a href="http://lattes.cnpq.br/0597440372595970">CV Lattes</a>
+                    <p class="lead mb-3">Professor Adjunto da Faculdade de Computação (FACOM) e Coordenador do Programa de Pós-Graduação em Ciência da Computação (PPGCC) da Universidade Federal de Mato Grosso do Sul (UFMS). Doutor e Mestre em Informática pelo PPGI da Universidade Federal do Amazonas (UFAM). Conduzo pesquisa científica nas áreas de Developer Relations (DevRel), Ecossistemas de Software e Engenharia de Software para Inteligência Artificial e Ciência de Dados. Coordeno o Laboratório de Engenharia de Software (LEDES) e o programa <a href="https://pantanal.dev" target="_blank">pantanal.dev</a> (iniciativa da B3), além de projetos com fomento externo (PDTec, BLK, Neoway).</p>
+                    <p class="lead mb-5">Tenho experiência com comunidades de desenvolvedores, tendo atuado por seis anos como developer evangelist para Nokia e Microsoft no Brasil e América Latina. Sou premiado como autor da melhor tese de doutorado do Brasil em Engenharia de Software e em Sistemas de Informação (SBC, 2020). Revisor de periódicos e membro de comitês técnicos de programas de conferências e workshops internacionais.</p>
+                    <div class="mb-3">
+                        <a href="https://dblp.org/pers/f/Font=atilde=o:Awdren_de_Lima.html" target="_blank">DBLP</a> |
+                        <a href="https://scholar.google.com.br/citations?user=BfesYF0AAAAJ&hl=en" target="_blank">Google Scholar</a> |
+                        <a href="https://www.researchgate.net/profile/Awdren_Fontao" target="_blank">ResearchGate</a> |
+                        <a href="http://lattes.cnpq.br/0597440372595970" target="_blank">CV Lattes</a> |
+                        <a href="https://orcid.org/0000-0002-2988-9646" target="_blank">ORCID</a>
+                    </div>
                     <div class="social-icons">
-                        <a class="social-icon" href="https://www.linkedin.com/in/awdren-font%C3%A3o-5087b121/"><i class="fab fa-linkedin-in"></i></a>
-                        <a class="social-icon" href="https://www.twitter.com/awdren"><i class="fab fa-twitter"></i></a>
+                        <a class="social-icon" href="https://www.linkedin.com/in/awdren-font%C3%A3o-5087b121/" target="_blank"><i class="fab fa-linkedin-in"></i></a>
+                        <a class="social-icon" href="https://www.twitter.com/awdren" target="_blank"><i class="fab fa-twitter"></i></a>
+                        <a class="social-icon" href="https://github.com/Awdren" target="_blank"><i class="fab fa-github"></i></a>
                     </div>
                 </div>
             </section>
@@ -85,6 +90,15 @@
                     <div class="d-flex flex-column flex-md-row justify-content-between mb-5">
                         <div class="flex-grow-1">
                             <h3 class="mb-0">Refereed Journal Papers</h3>
+                            <div class="subheading mb-3">2026</div>
+                            <p>COSTA, L. A. M.; DIAS, E.; RIBEIRO, D.; FONTÃO, AWDREN; SANTOS, R. P.; SEREBRENIK, A. Supporting software engineering managers in talent retention: The Brazilian context. <em>Empirical Software Engineering</em>, v. 31, p. 44, 2026. [Qualis A2]</p>
+                            <div class="subheading mb-3">2025</div>
+                            <p>COSTA, L. A. M.; FONTÃO, A.; SANTOS, R. P.; SEREBRENIK, A. Applying Generative Artificial Intelligence for Vulnerability Fixing in a Proprietary Software Ecosystem. <em>Journal of Systems and Software</em>, v. 1, p. 112723, 2025. [Qualis A2]</p>
+                            <p>ARAUJO, M. H.; COSTA, C.; FONTÃO, A. Technical Debt of Software Projects Based on Merge Code Comments. <em>Journal of Software Engineering Research and Development</em>, v. 13, p. 19–32, 2025. [Qualis A4]</p>
+                            <div class="subheading mb-3">2024</div>
+                            <p>DE MACEDO, G. T.; FONTÃO, AWDREN; GADELHA, BRUNO. Building soft skills through a role-play based approach for requirements engineering remote education. <em>Journal of the Brazilian Computer Society</em>, v. 1, p. 1, 2024. [Qualis A3]</p>
+                            <div class="subheading mb-3">2023</div>
+                            <p>FONTÃO, AWDREN; CLEGER-TAMAYO, S.; WIESE, IGOR; PEREIRA DOS SANTOS, RODRIGO; CLAUDIO DIAS-NETO, ARILO. A Developer Relations (DevRel) model to govern developers in Software Ecosystems. <em>Journal of Software-Evolution and Process</em>, v. 35, p. 1, 2023. [Qualis A4]</p>
                             <div class="subheading mb-3">2021</div>
                             <p>FONTÃO, AWDREN; CLEGER-TAMAYO, S. ; WIESE, IGOR ; SANTOS, R. P. ; Dias-Neto, Arilo . A Developer Relations (DevRel) model to govern developers in Software Ecosystems. Journal of Software-Evolution and Process, p. 1, 2021.</p>
                             <p>COSTA, L. A. M. ; FONTÃO, AWDREN ; SANTOS, R. P. . Towards Proprietary Software Ecosystem Governance Strategies Based on Health Metrics. IEEE TRANSACTIONS ON ENGINEERING MANAGEMENT, v. 69, p. 1, 2021.</p>
@@ -100,6 +114,31 @@
                     <div class="d-flex flex-column flex-md-row justify-content-between mb-5">
                         <div class="flex-grow-1">
                             <h3 class="mb-0">Refereed Conference/Workshop Papers</h3>
+                            <div class="subheading mb-3">2025</div>
+                            <p>WASSOUF-JR, E.; FUKUDA, P.; FONTÃO, AWDREN. Investigating the Developer Experience of LGBTQIAPN+ People in Agile Teams. In: <em>IEEE/ACM 47th International Conference on Software Engineering: Software Engineering in Society (ICSE-SEIS)</em>, Ottawa, 2025.</p>
+                            <p>WASSOUF, E. R.; PAIVA, D.; GAMA, K.; FONTÃO, AWDREN. The Developer Experience of LGBTQIA+ People in Agile Teams: A Multivocal Literature Review. In: <em>IEEE/ACM 18th International Conference on Cooperative and Human Aspects of Software Engineering (CHASE)</em>, Ottawa, 2025.</p>
+                            <p>OUTAO, J.; COSTA, L. A. M.; ZACARIAS, R.; FONTÃO, A.; CONSTANTINOU, E.; SANTOS, R. P.; SEREBRENIK, A. Proprietary Software Ecosystems: What We Already Know and Future Perspectives. In: <em>ACM/IEEE International Workshop on Software Engineering for Systems-of-Systems and Software Ecosystems (SESoS)</em>, Ottawa, 2025.</p>
+                            <p>COSTA, L. A.; FONTÃO, A. L.; CONSTANTINOU, E.; DOS SANTOS, R. P.; SEREBRENIK, A. Building the Landing Zone for Site Reliability Engineering: A Multivocal Literature Review. In: <em>39th Brazilian Symposium on Software Engineering (SBES 2025)</em>, Recife, 2025.</p>
+                            <p>AYACH, F.; LAMEIRÃO, V.; LEAO, R.; et al. Generating Proto-Personas through Prompt Engineering: A Case Study on Efficiency, Effectiveness, and Empathy. In: <em>SBES 2025</em>, Recife, 2025.</p>
+                            <p>BUENO, A. R. R. N.; CAFEO, B.; CAGNIN, M. I.; FONTAO, AWDREN. Socio-Technical Smell Dynamics in Code Samples: A Multivocal Review. In: <em>SBES 2025</em>, Recife, 2025.</p>
+                            <p>OLIVEIRA, M.; et al. Um relatório de análise dos cursos de graduação em ES no Brasil: revelações e insights. In: <em>SBES 2025 – Education Track</em>, Recife, 2025.</p>
+                            <p>BUENO, A. R. R. N.; BEZERRA, C.; CAFEO, B.; CAGNIN, M. I.; FONTÃO, A. Evolutionary Analysis of the Co-occurrence between Code Smells and Community Smells in Code Samples. In: <em>XXI Brazilian Symposium on Information Systems (SBSI)</em>, Recife, 2025.</p>
+                            <p>FERREIRA, G.; ALBUQUERQUE, M.; SOARES, M.; FONTÃO, A.; PAIVA, D. M. B. Diretrizes Pedagógicas e de Acessibilidade para Jogos Educativos Digitais. In: <em>SBSI 2025</em>, Recife, 2025.</p>
+                            <p>SILVA JUNIOR, C. C.; et al. Framing Cloud Migration of Legacy Systems as Technical Sustainability Requirements within a Proprietary Software Ecosystem. In: <em>Workshop on Requirements Engineering (WER)</em>, Rio de Janeiro, 2025.</p>
+                            <div class="subheading mb-3">2024</div>
+                            <p>COSTA, L. A.; DIAS, E.; RIBEIRO, D.; FONTÃO, AWDREN; et al. An Actionable Framework for Understanding and Improving Talent Retention as a Competitive Advantage in IT Organizations. In: <em>IEEE/ACM 46th International Conference on Software Engineering: Companion Proceedings (ICSE Companion)</em>, Lisbon, 2024.</p>
+                            <p>LEÃO, R.; AYACH, F.; LAMEIRÃO, V.; FONTÃO, AWDREN. A Prompt Engineering-based Process to Build Proto-personas during Lean Inception. In: <em>XXXVIII Simpósio Brasileiro de Engenharia de Software (SBES 2024)</em>, 2024.</p>
+                            <p>MELGAREJO, J. L.; FONTÃO, AWDREN; BORGES, H. S. Why is my community reacting like this? Understanding reactions in open-source communities. In: <em>SBES 2024</em>, 2024.</p>
+                            <p>MOTA, L. L.; SANTOS, R. P.; FONTÃO, AWDREN; ARAÚJO, A. A. From Theory to Interpreting the Practice: Exploring the Role-play to Teach DevOps. In: <em>SBES 2024</em>, 2024.</p>
+                            <p>SOARES, M. S.; et al. Pedagogical and accessibility guidelines for open educational resources focusing on blind students. In: <em>XXIII Brazilian Symposium on Human Factors in Computing Systems (IHC 2024)</em>, Brasília, 2024.</p>
+                            <p>SOBRINHO, R. R.; et al. Um estudo preliminar da migração de comunidade dos projetos nos ecossistemas AngularJS e Angular. In: <em>Anais Estendidos do XX SBSI</em>, 2024.</p>
+                            <div class="subheading mb-3">2023</div>
+                            <p>ARANTES, P.; SOUPINSKI, F.; FONTÃO, AWDREN. <strong>Social Networks during Software Ecosystems' Death.</strong> In: <em>IEEE/ACM 11th International Workshop on Software Engineering for Systems-of-Systems and Software Ecosystems (SESoS @ ICSE)</em>, Melbourne, 2023. <em>⭐ Best Short Paper Award.</em></p>
+                            <p>FONTÃO, AWDREN; MATSUBARA, E.; MONGELLI, H.; et al. Hyacinth macaw: a project-based learning program to develop talents in Software Engineering for Artificial Intelligence. In: <em>XXXVII Brazilian Symposium on Software Engineering (SBES 2023)</em>, Campo Grande, 2023.</p>
+                            <p>MELO DE ARAÚJO, M. H.; COSTA, C.; FONTÃO, AWDREN. <strong>Analysis of the Technical Debt of Software Projects Based on Merge Code Comments.</strong> In: <em>17th Brazilian Symposium on Software Components, Architectures, and Reuse (SBCARS 2023)</em>, Campo Grande, 2023. <em>⭐ Distinguished Paper Award.</em></p>
+                            <p>DE MACEDO, G. T.; FONTÃO, AWDREN; GADELHA, B. UIProtoCheck: A Checklist for Semantic Inspection of User Interface Prototypes. In: <em>SBES 2023</em>, Campo Grande, 2023.</p>
+                            <p>COSTA, L. A.; SAMPAIO, A.; FONTÃO, AWDREN; SANTOS, R. P. Investigating Change and Incident Management in a Proprietary Software Ecosystem – Survival Mode On. In: <em>XII Brazilian Workshop on Social Network Analysis and Mining (BraSNAM 2023)</em>, 2023.</p>
+                            <p>ARANTES, P.; FONTÃO, AWDREN. Analisando a Morte de Ecossistemas de Software para plataformas Web a partir da abordagem de Redes Sociais e Reciclagem de Recursos. In: <em>XIV Congresso Brasileiro de Software: Teoria e Prática – CBSoft Estendido 2023</em>, 2023.</p>
                             <div class="subheading mb-3">2022</div>
                             <p>SOUPINSKI, F. ; ARANTES, P. ; STEINMACHER, I. ; WIESE, IGOR ; BORGES, H. S. ; CAFEO, B. B. P. ; FONTÃO, AWDREN . 'We are dying!' On Death Signals of Software Ecosystems. In: Brazilian Symposium on Software Engineering (SBES 2022), 2022, Uberlândia. Proceedings of the 36th Brazilian Symposium on Software Engineering (SBES 2022) - Insightful Ideas and Emerging Results Track, 2022</p>
                             <p>MAIA, K. ; PEREIRA, M. ; MONTEIRO, G. ; FONTÃO, AWDREN . Pattern with partners: A systematic approach to handle knowledge sharing in GSD projects. In: 17th ACM/IEEE International Conference on Global Software Engineering - ICGSE, 2022, Pittsburgh. Proceedings of the 17th ACM/IEEE International Conference on Global Software Engineering - ICGSE, 2022.</p>
@@ -152,16 +191,18 @@
             <section class="resume-section" id="education">
                 <div class="resume-section-content">
                     <h2 class="mb-5">Research</h2>
-                    I research the intersections of the Software Ecosystem (SECO) and Software Engineering (SE) areas, mainly on topics related to Developer Relations (DevRel) and Developer eXperience (DX).
-                    <div class="d-flex flex-column flex-md-row justify-content-between mb-5">
-                        <div class="flex-grow-1">
-                            <h3 class="mb-0">Current Research Topics</h3>
-                            <div class="subheading mb-3">Developer Relations (DevRel)</div>
-                            <p>There is a need for strategies to support the SECO capacity to increase or maintain its developer communities over time and survive inherent changes. In this scenario, the Developer Relations (DevRel) team emerge as a possible strategy. DevRel can be defined as: “it is about creating a vibrant ecosystem of third-party developers, by being the interface between those developers and the platform’s product, engineering, and design teams”. As part of SECO governance, planning and execution of DevRel activities is not trivial and focus on delimiting developer actions without excessively restricting the desired level of value creation. </p>
-                            <div class="subheading mb-3">Software Ecosystem</div>
-                            <p>The new dynamic of interactions between third-party users, developers, companies around a common platform has moved the organizations that maintain software platforms towards expanding their platforms, attracting developers and meeting the demands of users [1][2]. This scenario, which involves technical (i.e., the development process), social (i.e., interaction among users, companies and third-party/internal developers), and business (i.e., synergy surrounded by organizational intentions and developer expectations) dimensions, has been known as Software Ecosystem (SECO)</p>
-                            <div class="subheading mb-3">Software Engineering</div>
-                            <p>Experimental and Empirical Software Engineering | Mining Software Repositories | Software Testing, Verification and Validation | Education | </p>
+                    I research the intersections of Software Engineering, Software Ecosystems, and Artificial Intelligence, focusing on Developer Relations (DevRel), Developer eXperience (DX), and Software Engineering for/with AI.
+                    <div class=”d-flex flex-column flex-md-row justify-content-between mb-5”>
+                        <div class=”flex-grow-1”>
+                            <h3 class=”mb-0”>Current Research Topics</h3>
+                            <div class=”subheading mb-3”>Developer Relations (DevRel) &amp; Developer eXperience (DX)</div>
+                            <p>DevRel is the interface between third-party developers and a platform’s product, engineering, and design teams. As part of Software Ecosystem governance, I investigate how DevRel teams create value, govern developer communities, and sustain ecosystems over time. Research topics include DevRel roles and skills, value creation strategies, and governance models for mobile and proprietary ecosystems.</p>
+                            <div class=”subheading mb-3”>Software Engineering for/with Artificial Intelligence (SE4AI / SE4DS)</div>
+                            <p>With the growing adoption of Machine Learning and Deep Learning in software products, specific Software Engineering challenges arise: model traceability, technical debt in ML pipelines, architecture of intelligent systems, and security. I investigate engineering practices applied to AI-based systems, including MLOps, AIOps, prompt engineering, and security tactics for intelligent software architectures.</p>
+                            <div class=”subheading mb-3”>Software Ecosystems (SECO)</div>
+                            <p>Software Ecosystems involve the technical, social, and business dimensions of interactions among platforms, developers, and users. I research SECO governance, health metrics, ecosystem death signals, and mining of software repositories to understand community dynamics.</p>
+                            <div class=”subheading mb-3”>Software Engineering (SE)</div>
+                            <p>Experimental and Empirical Software Engineering | Mining Software Repositories | Software Testing, Verification and Validation | Software Engineering Education</p>
                         </div>
                     </div>
                     <div class="d-flex flex-column flex-md-row justify-content-between">
@@ -188,92 +229,70 @@
             <section class="resume-section" id="skills">
                 <div class="resume-section-content">
                     <h2 class="mb-5">Students</h2>
-                    <div class="subheading mb-3">My current students</div>
-                    <ul class="fa-ul mb-0">
-                        <li>
-                            <span class="fa-li"><i class="fas fa-check"></i></span>
-                            Luiz Alexandre Martins da Costa (MSc. @UNIRIO| co-supervisor) An Approach to Incident Management in Proprietary Software Ecosystems
-                        </li>
 
-                        <li>
-                            <span class="fa-li"><i class="fas fa-check"></i></span>
-                            Rafael Araújo de Lima (MSc. student @FACOM/UFMS) Antecipating DevOps practices on software development process.
-                        </li>
-                        <li>
-                            <span class="fa-li"><i class="fas fa-check"></i></span>
-                            Raphael Arruda de Oliveira (Undergrad @FACOM/UFMS) Defining Roles for Developer Relations (DevRel):an Exploratory Study on Practitioners’ opinions
-                        </li>
-                        <li>
-                            <span class="fa-li"><i class="fas fa-check"></i></span>
-                            Fernando Kendy Yahiro (Undergrad @FACOM/UFMS) The style of open-source machine learning benchmark projects focused on the analysis of sentiments, emotions and hate speech.
-                        </li>
-                        <li>
-                            <span class="fa-li"><i class="fas fa-check"></i></span>
-                            Victor Koji (Undergrad @FACOM/UFMS) Exploring sentiments in Gitter discussion threads
-                        </li>
-                        <li>
-                            <span class="fa-li"><i class="fas fa-check"></i></span>
-                            Mateus Ragazzi (Undergrad @FACOM/UFMS) Proposing bug severity to newcomers
-                        </li>
-                        <li>
-                            <span class="fa-li"><i class="fas fa-check"></i></span>
-                            Igor Braga Galvan (Undergrad @FACOM/UFMS) On applying Ecological Modeling in Software Ecosystem research
-                        </li>
-                        <li>
-                            <span class="fa-li"><i class="fas fa-check"></i></span>
-                            Felipe Soupinski (Undergrad @FACOM/UFMS) A Developer Relations (DevRel) perspective of Software Ecosystems' Death
-                        </li>
+                    <div class="subheading mb-3">Current Students — Doctorate (PhD)</div>
+                    <ul class="fa-ul mb-4">
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Ricardo Kondo (PhD @PPGCC/UFMS, 2026–) A definir.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Jose Vieira dos Santos Neto (PhD @PPGCC/UFMS, 2025–) A definir.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Luiz Alexandre Martins da Costa (PhD @PPGI/UNIRIO, 2022– | co-supervisor) A definir.</li>
                     </ul>
-                    <div class="subheading mb-3">Alumni</div>
+
+                    <div class="subheading mb-3">Current Students — Master’s (MSc)</div>
+                    <ul class="fa-ul mb-4">
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Diogo Menezes (MSc @PPGCC/UFMS, 2026–) MLOps Branching Echoes.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Ryan Breda (MSc @PPGCC/UFMS, 2026–) A definir.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Enzo Moraes Pereira (MSc @PPGCC/UFMS, 2025–) Direcionadores e intertemporalidade em decisões arquiteturais de software inteligente.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Rafael Rogado Ribeiro Sobrinho (MSc @PPGCC/UFMS, 2025–) Uma arquitetura de AIOps para otimizar o monitoramento de produto de software.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Jorge Luiz Freitas Costa (MSc @PPGCC/UFMS, 2025–) A definir.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>João Lucas Machado (MSc @PPGCC/UFMS, 2025–) A definir.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Breno José Vergílio (MSc @PPGCC/UFMS, 2024–) Táticas de segurança para arquitetura de software baseada em IA.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Lucas Henrique Alves Borth (MSc @PPGCC/UFMS, 2024–) A definir.</li>
+                    </ul>
+
+                    <div class="subheading mb-3">Current Students — Scientific Initiation (IC)</div>
+                    <ul class="fa-ul mb-4">
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Gabriel Caitano — Testes de Software com IA: Guia Prático para Novatos na Identificação e Correção de Vieses e Vulnerabilidades.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Matheus Bernard — Um experimento de RAG em modelos de código: uma perspectiva de Engenharia de Software seguro.</li>
+                    </ul>
+
+                    <div class="subheading mb-3">Current Students — Undergraduate (TCC)</div>
+                    <ul class="fa-ul mb-4">
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Juliano Necar (@FACOM/UFMS) — Conjunto de heurísticas para data linter em versionamento de bases de dados.</li>
+                    </ul>
+
+                    <div class="subheading mb-3">Alumni — Master’s</div>
+                    <ul class="fa-ul mb-4">
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Arthur Ramires Rodrigues Neto Bueno (MSc @PPGCC/UFMS, 2026) — Evolução da co-ocorrência entre code smells e community smells em projetos open-source.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Felipe Soupinski (MSc @PPGCC/UFMS, 2025) — An approach to analyze and mitigate the impacts of Software Ecosystems’ Death.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Edvaldo Roberto Wassouf Junior (MSc @PPGCC/UFMS, 2025) — Framework para melhoria da experiência de desenvolvedores LGBTQIAPN+ em equipes de desenvolvimento de software ágil.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Ana Elisa da Silva Cunha (MSc @PPGCC/UFMS, 2021) — Um modelo baseado em habilidades para formação de profissionais de Developer Relations.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Luiz Alexandre Martins da Costa (MSc @PPGI/UNIRIO, 2019 | co-supervisor) — Uma Abordagem para Gestão de Incidentes em Ecossistemas de Software Proprietário.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Oswald Mesumbe Ekwoge (MSc @ICOMP/UFAM, 2018 | co-supervisor) — Tester Experience: Uma Abordagem para Melhorar a Experiência do Testador em Projetos de Software.</li>
+                    </ul>
+
+                    <div class="subheading mb-3">Alumni — Undergraduate (FACOM/UFMS)</div>
+                    <ul class="fa-ul mb-4">
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Raphael Arruda de Oliveira — Defining Roles for Developer Relations (DevRel): an Exploratory Study on Practitioners’ opinions.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Rafael Araújo de Lima — Supporting DevRel practitioners in selecting relevant strategies.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Felipe Soupinski — A Developer Relations (DevRel) perspective of Software Ecosystems’ Death.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Fernando Kendy Yahiro — The style of open-source machine learning benchmark projects.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Victor Koji — Exploring sentiments in Gitter discussion threads.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Mateus Ragazzi — Proposing bug severity to newcomers.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Igor Braga Galvan — On applying Ecological Modeling in Software Ecosystem research.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Daniel Massanori — On Investigating the Death of Software Ecosystems: Windows Phone Scenario.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Flavio Augusto — A strategy to support onboarding of novice software testers.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Willian Braga — Code Samples as enablers for Developer Relations in Software Ecosystems.</li>
+                    </ul>
+
+                    <div class="subheading mb-3">Alumni — Undergraduate (ICOMP/UFAM)</div>
                     <ul class="fa-ul mb-0">
-                        <li>
-                            <span class="fa-li"><i class="fas fa-check"></i></span>
-                            Rafael Araújo de Lima (Undergrad @FACOM/UFMS) Supporting DevRel practitioners in selecting relevant strategies.
-                        </li>
-                        <li>
-                            <span class="fa-li"><i class="fas fa-check"></i></span>
-                            Daniel Massanori (Undergrad @FACOM/UFMS) On Investigating the Death of Software Ecosystems - Windows Phone Scenario
-                        </li>
-                        <li>
-                            <span class="fa-li"><i class="fas fa-check"></i></span>
-                            Flavio Augusto (Undergrad @FACOM/UFMS) A strategy to support onboarding of novice software testers
-                        </li>
-                        <li>
-                            <span class="fa-li"><i class="fas fa-check"></i></span>
-                            Willian Braga (Undergrad @FACOM/UFMS) Code Samples as enablers for Developer Relations in Software Ecosystems
-                        </li>
-                        <li>
-                            <span class="fa-li"><i class="fas fa-check"></i></span>
-                            Oswald Mesumbe Ekwoge (MSc. @ICOMP/UFAM | co-supervisor | 2016-2018). Tester Experience: Uma Abordagem para Melhorar a Experiência do Testador em Projetos de Software.
-                        </li>
-                        <li>
-                            <span class="fa-li"><i class="fas fa-check"></i></span>
-                            Marcos Hiroshi Saito Bezerra (Undergrad @ICOMP/UFAM | 2018) Um estudo sobre as barreiras enfrentadas por testadores novatos de apps.
-                        </li>
-                        <li>
-                            <span class="fa-li"><i class="fas fa-check"></i></span>
-                            Kleyfferson Lima Silva (Undergrad @ICOMP/UFAM | 2018) Um estudo sobre a adoção do Scrum por equipes de projetos de larga escala
-                        </li>
-                        <li>
-                            <span class="fa-li"><i class="fas fa-check"></i></span>
-                            Gabriel Gama (Undergrad @ICOMP/UFAM | 2018).​Uma ferramenta para apoiar o uso do Scrum com equipes remotas
-                        </li>
-                        <li>
-                            <span class="fa-li"><i class="fas fa-check"></i></span>
-                            Fabrício José da Silva Lima (Undergrad @ICOMP/UFAM | co-supervisor | 2017). Entendendo MSECO a partir de Análise de Dados Técnicos do Stack Overflow
-                        </li>
-                        <li>
-                            <span class="fa-li"><i class="fas fa-check"></i></span>
-                            Schweitzer Wostewoysers Campelo (Undergrad @ICOMP/UFAM | co-supervisor | 2016). Analisando a Relação entre Relatos de Falhas e Ratings em Comentários de Aplicações Móveis na Loja Google Play
-                        </li>
-                        <li>
-                            <span class="fa-li"><i class="fas fa-check"></i></span>
-                            Ludymila Lobo Aguiar Gomes (Undergrad @ICOMP/UFAM | co-supervisor | 2015). Identificando nichos em Ecossistemas de Aplicativos Móveis
-                        </li>
-                        <li>
-                            <span class="fa-li"><i class="fas fa-check"></i></span>
-                            Caio Biase Grana (Undergrad @ICET/UFAM | co-supervisor | 2015). Realizando um estudo do método UX Curve aplicado a Experiência do Desenvolvedor.
-                        </li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Marcos Hiroshi Saito Bezerra (2018) — Um estudo sobre as barreiras enfrentadas por testadores novatos de apps.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Kleyfferson Lima Silva (2018) — Um estudo sobre a adoção do Scrum por equipes de projetos de larga escala.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Gabriel Gama (2018) — Uma ferramenta para apoiar o uso do Scrum com equipes remotas.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Fabrício José da Silva Lima (2017 | co-supervisor) — Entendendo MSECO a partir de Análise de Dados Técnicos do Stack Overflow.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Schweitzer W. Campelo (2016 | co-supervisor) — Analisando a Relação entre Relatos de Falhas e Ratings em Comentários de Apps na Google Play.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Ludymila Lobo Aguiar Gomes (2015 | co-supervisor) — Identificando nichos em Ecossistemas de Aplicativos Móveis.</li>
+                        <li><span class="fa-li"><i class="fas fa-check"></i></span>Caio Biase Grana (2015 | co-supervisor) — Realizando um estudo do método UX Curve aplicado a Experiência do Desenvolvedor.</li>
                     </ul>
                 </div>
             </section>
@@ -283,6 +302,26 @@
                 <div class="resume-section-content">
                     <h2 class="mb-5">Awards</h2>
                     <ul class="fa-ul mb-0">
+                        <li>
+                            <span class="fa-li"><i class="fas fa-trophy text-warning"></i></span>
+                            (2025) Distinguished Reviewer – 21st Brazilian Symposium on Information Systems (SBSI) – Research Track, Sociedade Brasileira de Computação.
+                        </li>
+                        <li>
+                            <span class="fa-li"><i class="fas fa-trophy text-warning"></i></span>
+                            (2025) Distinguished Reviewer – XXXIX Simpósio Brasileiro de Engenharia de Software (SBES) – Education Track, Sociedade Brasileira de Computação.
+                        </li>
+                        <li>
+                            <span class="fa-li"><i class="fas fa-trophy text-warning"></i></span>
+                            (2025) Paraninfo da turma de Engenharia de Software (2025.1) da FACOM, UFMS.
+                        </li>
+                        <li>
+                            <span class="fa-li"><i class="fas fa-trophy text-warning"></i></span>
+                            (2025) 3º lugar – Concurso de Iniciação Científica do XXIV Simpósio Brasileiro de Qualidade de Software (SBQS) – Aluno: Matheus Oliveira. Orientador: Awdren Fontão. Coorientador: Jonathan Andrade.
+                        </li>
+                        <li>
+                            <span class="fa-li"><i class="fas fa-trophy text-warning"></i></span>
+                            (2025) Patrono da turma de Engenharia de Software (2025.2) da FACOM, UFMS.
+                        </li>
                         <li>
                             <span class="fa-li"><i class="fas fa-trophy text-warning"></i></span>
                             (2024) 3º lugar - Concurso de Iniciação Científica (CTIC) do XXXVIII Simpósio Brasileiro de Engenharia de Software (SBES) - Aluno: Fernando Ayach. Orientador: Awdren Fontão, Sociedade Brasileira de Computação.


### PR DESCRIPTION
## Summary

- **About**: Cargo atualizado para Coordenador do PPGCC/UFMS, bio reescrita com foco em SE4AI, LEDES, pantanal.dev (B3) e premiação SBC 2020; ORCID e GitHub adicionados
- **Research**: Nova seção de Software Engineering for/with AI (SE4AI/SE4DS) junto com DevRel, SECO e SE
- **Publications**: +14 artigos em periódicos (2023–2026) e +22 trabalhos em conferências (2023–2025), com Best Short Paper (SESoS/ICSE 2023) e Distinguished Paper (SBCARS 2023) marcados
- **Students**: Seção completamente refeita — 3 doutorandos, 8 mestrandos, 2 ICs, 1 TCC ativos; alumni expandido com todos os mestres concluídos (2021–2026)
- **Awards**: +5 prêmios de 2025 (Distinguished Reviewer SBSI, Distinguished Reviewer SBES, Paraninfo 2025.1, 3º SBQS, Patrono 2025.2)

## Source

Data extracted from LinkedIn profile (PDF) and Lattes CV (21/05/2026 update).

## Test plan

- [ ] Verify all sections render correctly on desktop and mobile
- [ ] Check all external links (ORCID, GitHub, Lattes, Scholar, DBLP) are working
- [ ] Confirm new publications appear under correct year headings
- [ ] Confirm Students section correctly separates current from alumni