### PR TITLE
Modernize site: Font Awesome 6, Mulish font, Bootstrap 4.6.2, meta tags, responsive videos

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -60,7 +60,7 @@ article, aside, figcaption, figure, footer, header, hgroup, main, nav, section {
 
 body {
   margin: 0;
-  font-family: "Muli", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-family: "Mulish", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5;
@@ -5587,7 +5587,7 @@ a.close.disabled {
   z-index: 1070;
   display: block;
   margin: 0;
-  font-family: "Muli", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-family: "Mulish", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-style: normal;
   font-weight: 400;
   line-height: 1.5;
@@ -5689,7 +5689,7 @@ a.close.disabled {
   z-index: 1060;
   display: block;
   max-width: 276px;
-  font-family: "Muli", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-family: "Mulish", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-style: normal;
   font-weight: 400;
   line-height: 1.5;

--- a/index.html
+++ b/index.html
@@ -3,16 +3,25 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-        <meta name="description" content="" />
-        <meta name="author" content="" />
-        <title>Awdren Fontão, PhD - FACOM/UFMS</title>
+        <meta name="description" content="Awdren Fontão, PhD — Professor Adjunto e Coordenador do PPGCC, FACOM/UFMS. Pesquisador em DevRel, Ecossistemas de Software e Engenharia de Software para IA." />
+        <meta name="author" content="Awdren de Lima Fontão" />
+        <!-- Open Graph -->
+        <meta property="og:title" content="Awdren Fontão, PhD — FACOM/UFMS" />
+        <meta property="og:description" content="Professor, Researcher, and Software Engineer. DevRel, Software Ecosystems, SE for AI." />
+        <meta property="og:type" content="website" />
+        <meta property="og:image" content="assets/img/profile.jpg" />
+        <!-- Twitter / X -->
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:creator" content="@awdren" />
+        <title>Awdren Fontão, PhD — FACOM/UFMS</title>
         <link rel="icon" type="image/x-icon" href="assets/img/favicon.ico" />
-        <!-- Font Awesome icons (free version)-->
-        <script src="https://use.fontawesome.com/releases/v5.13.0/js/all.js" crossorigin="anonymous"></script>
-        <!-- Google fonts-->
-        <link href="https://fonts.googleapis.com/css?family=Saira+Extra+Condensed:500,700" rel="stylesheet" type="text/css" />
-        <link href="https://fonts.googleapis.com/css?family=Muli:400,400i,800,800i" rel="stylesheet" type="text/css" />
-        <!-- Core theme CSS (includes Bootstrap)-->
+        <!-- Font Awesome 6 (CSS, replaces v5 JS) -->
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" />
+        <!-- Google Fonts (Mulish replaces Muli; modern format with display=swap) -->
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link href="https://fonts.googleapis.com/css2?family=Saira+Extra+Condensed:wght@500;700&family=Mulish:ital,wght@0,400;0,800;1,400;1,800&display=swap" rel="stylesheet" />
+        <!-- Core theme CSS (includes Bootstrap 4) -->
         <link href="css/styles.css" rel="stylesheet" />
     </head>
     <body id="page-top">
@@ -20,7 +29,7 @@
         <nav class="navbar navbar-expand-lg navbar-dark bg-primary fixed-top" id="sideNav">
             <a class="navbar-brand js-scroll-trigger" href="#page-top">
                 <span class="d-block d-lg-none">Awdren Fontão, PhD</span>
-                <span class="d-none d-lg-block"><img class="img-fluid img-profile rounded-circle mx-auto mb-2" src="assets/img/profile.jpg" alt="" /></span>
+                <span class="d-none d-lg-block"><img class="img-fluid img-profile rounded-circle mx-auto mb-2" src="assets/img/profile.jpg" alt="Awdren Fontão" /></span>
             </a>
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
@@ -59,22 +68,40 @@
                     </div>
                 </div>
             </section>
-            <!-- Interests -->
+            <!-- Media -->
             <section class="resume-section" id="interviews">
                 <div class="resume-section-content">
-                    <h2 class="mb-5">Interviews on YouTube, Twitch and etc...</h2>
-                    <iframe width="560" height="315" src="https://www.youtube.com/embed/qWjTgugi0Kw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-                    <iframe width="560" height="315" src="https://www.youtube.com/embed/1M0_PoA5MUo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-                    <iframe width="560" height="315" src="https://www.youtube.com/embed/Mg_x2OiRHZA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-                    <iframe width="560" height="315" src="https://player.twitch.tv/?video=1539325770&parent=www.example.com" frameborder="0" allowfullscreen="true" scrolling="no"></iframe>
-                    <br/>
-                  <h2 class="mb-5">Interviews on Podcasts</h2>
-                    <iframe style="border-radius:12px" src="https://open.spotify.com/embed/episode/19yhjri7rtmkaWqczZyyZK?utm_source=generator" width="100%" height="232" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>
-                    <iframe style="border-radius:12px" src="https://open.spotify.com/embed/episode/0n27rjX05lASplDVYZxgb8?utm_source=generator" width="100%" height="232" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>
-                    <br/>
-                    <h2 class="mb-5">Content on Dev.To</h2>
-                    <a href="https://dev.to/awdren/devrel-developer-relations-relacoes-com-desenvolvedores-ei2"> (In Portuguese) DevRel, Developer Relations, Relações com desenvolvedores </a>
-                </div>
+                    <h2 class="mb-5">Media</h2>
+
+                    <h3 class="mb-3">Interviews &middot; YouTube</h3>
+                    <div class="row mb-4">
+                        <div class="col-lg-6 mb-3">
+                            <div class="embed-responsive embed-responsive-16by9">
+                                <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/qWjTgugi0Kw" title="Interview on YouTube" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                            </div>
+                        </div>
+                        <div class="col-lg-6 mb-3">
+                            <div class="embed-responsive embed-responsive-16by9">
+                                <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/1M0_PoA5MUo" title="Interview on YouTube" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                            </div>
+                        </div>
+                        <div class="col-lg-6 mb-3">
+                            <div class="embed-responsive embed-responsive-16by9">
+                                <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/Mg_x2OiRHZA" title="Interview on YouTube" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                            </div>
+                        </div>
+                    </div>
+
+                    <h3 class="mb-3">Interviews &middot; Podcasts</h3>
+                    <div class="mb-3">
+                        <iframe style="border-radius:12px" src="https://open.spotify.com/embed/episode/19yhjri7rtmkaWqczZyyZK?utm_source=generator" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>
+                    </div>
+                    <div class="mb-4">
+                        <iframe style="border-radius:12px" src="https://open.spotify.com/embed/episode/0n27rjX05lASplDVYZxgb8?utm_source=generator" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>
+                    </div>
+
+                    <h3 class="mb-3">Posts &middot; Dev.To</h3>
+                    <a href="https://dev.to/awdren/devrel-developer-relations-relacoes-com-desenvolvedores-ei2" target="_blank">(em Português) DevRel · Developer Relations · Relações com desenvolvedores</a>
                 </div>
             </section>
             <hr class="m-0" />
@@ -421,11 +448,11 @@
                 </div>
             </section>
         </div>
-        <!-- Bootstrap core JS-->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.bundle.min.js"></script>
+        <!-- Bootstrap 4 JS -->
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.2/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
         <!-- Third party plugin JS-->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.4.1/jquery.easing.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.4.1/jquery.easing.min.js" crossorigin="anonymous"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
     </body>


### PR DESCRIPTION
## Summary

- **Font Awesome v5 → v6**: troca de JS para CSS link — menor payload, sem execução JS no parse
- **Mulish** (substituta oficial do Muli no Google Fonts): URL atualizada para formato `css2` com `display=swap` e hints `preconnect`
- **Bootstrap 4.5.0 → 4.6.2** e **jQuery 3.5.1 → 3.7.1**: versões mais recentes da linha 4.x via cdnjs (mais confiável que stackpath)
- **Meta tags SEO/social**: `meta description`, Open Graph (`og:title`, `og:description`, `og:type`, `og:image`) e Twitter/X card — melhora preview ao compartilhar
- **Vídeos responsivos**: YouTube iframes agora usam `embed-responsive embed-responsive-16by9` em grid `col-lg-6` — escalam corretamente em mobile
- **Twitch embed removido**: tinha `parent=www.example.com` (URL placeholder quebrada)
- **Spotify player**: altura compacta 232 → 152px (player moderno)
- **Bug**: `</div>` duplicado na seção media corrigido
- **`alt` attribute** adicionado na foto de perfil
- **`css/styles.css`**: 3 ocorrências de `"Muli"` → `"Mulish"` para consistência com o font carregado

## Test plan

- [ ] Verificar fontes renderizando corretamente (Mulish body, Saira Extra Condensed headings)
- [ ] Conferir ícones Font Awesome 6 (LinkedIn, Twitter/GitHub nas social icons)
- [ ] Testar vídeos YouTube responsivos em mobile e desktop
- [ ] Confirmar que Open Graph aparece ao compartilhar link no WhatsApp/LinkedIn
- [ ] Confirmar ausência de erros de console (CDN, CORS)